### PR TITLE
Feature/read

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
 }
 
 dependencies {
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/tunaforce/hub/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/tunaforce/hub/common/config/RedisCacheConfig.java
@@ -1,0 +1,30 @@
+package com.tunaforce.hub.common.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))  // TTL 10분
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .disableCachingNullValues();
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+}

--- a/src/main/java/com/tunaforce/hub/common/exception/HubException.java
+++ b/src/main/java/com/tunaforce/hub/common/exception/HubException.java
@@ -14,6 +14,8 @@ public enum HubException {
     INVALID_HUB_ADDRESS(HttpStatus.BAD_REQUEST, "유효하지 않은 주소입니다."),
     HUB_NO_CHANGE(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
 
+    INVALID_PAGE_OR_SIZE(HttpStatus.BAD_REQUEST, "page는 0 이상의 정수, size는 1 이상의 정수여야 합니다."),
+
     // Auth
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     INVALID_REQUESTED_COMPANY_OR_HUB(HttpStatus.BAD_REQUEST, "요청한 허브 또는 업체가 유효하지 않습니다."),

--- a/src/main/java/com/tunaforce/hub/controller/HubController.java
+++ b/src/main/java/com/tunaforce/hub/controller/HubController.java
@@ -47,6 +47,7 @@ public class HubController {
         return new ResponseEntity<>(hubService.getHub(hubId), HttpStatus.OK);
     }
 
+    /*허브 목록 조회 API*/
     @GetMapping
     public ResponseEntity<List<HubGetResponseDto>> getHubList(@RequestParam(defaultValue = "0") int page,
                                                               @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/com/tunaforce/hub/controller/HubController.java
+++ b/src/main/java/com/tunaforce/hub/controller/HubController.java
@@ -4,6 +4,7 @@ import com.tunaforce.hub.dto.request.HubCreateRequestDto;
 import com.tunaforce.hub.dto.request.HubUpdateRequestDto;
 import com.tunaforce.hub.dto.response.HubCreateResponseDto;
 import com.tunaforce.hub.dto.response.HubDeleteResponseDto;
+import com.tunaforce.hub.dto.response.HubGetResponseDto;
 import com.tunaforce.hub.dto.response.HubUpdateResponseDto;
 import com.tunaforce.hub.service.HubService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -37,6 +39,18 @@ public class HubController {
     @DeleteMapping("/{hubId}")
     public ResponseEntity<HubDeleteResponseDto> deleteHub(@PathVariable UUID hubId) {
         return new ResponseEntity<>(hubService.deleteHub(hubId), HttpStatus.OK);
+    }
+
+    /*허브 단건 조회 API*/
+    @GetMapping("/{hubId}")
+    public ResponseEntity<HubGetResponseDto> getHub(@PathVariable UUID hubId) {
+        return new ResponseEntity<>(hubService.getHub(hubId), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<HubGetResponseDto>> getHubList(@RequestParam(defaultValue = "0") int page,
+                                                              @RequestParam(defaultValue = "10") int size) {
+        return new ResponseEntity<>(hubService.getHubList(page, size), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/tunaforce/hub/dto/response/HubGetResponseDto.java
+++ b/src/main/java/com/tunaforce/hub/dto/response/HubGetResponseDto.java
@@ -1,0 +1,10 @@
+package com.tunaforce.hub.dto.response;
+
+import java.util.UUID;
+
+public record HubGetResponseDto(UUID hubId,
+                                String hubName,
+                                String hubAddress,
+                                Double hubLatitude,
+                                Double hubLongitude) {
+}

--- a/src/main/java/com/tunaforce/hub/entity/Hub.java
+++ b/src/main/java/com/tunaforce/hub/entity/Hub.java
@@ -24,10 +24,10 @@ public class Hub extends Timestamped {
     @Column(name = "hub_address", nullable = false)
     private String hubAddress;
 
-    @Column(name = "hub_latitude")
+    @Column(name = "hub_latitude", nullable = false)
     private Double hubLatitude;
 
-    @Column(name = "hub_longitude")
+    @Column(name = "hub_longitude", nullable = false)
     private Double hubLongitude;
 
     @Column(name = "hub_admin_id")

--- a/src/main/java/com/tunaforce/hub/repository/HubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/HubRepository.java
@@ -1,7 +1,9 @@
 package com.tunaforce.hub.repository;
 
 import com.tunaforce.hub.entity.Hub;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -9,4 +11,5 @@ public interface HubRepository{
     Hub save(Hub hub);
     Optional<Hub> findById(UUID hubId);
     boolean existsByHubName(String hubName);
+    List<Hub> findAll(Pageable pageable);
 }

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
@@ -24,17 +24,17 @@ public class HubRepositoryImpl implements HubRepository {
 
     @Override
     public Optional<Hub> findById(UUID hubId) {
-        return jpaHubRepository.findById(hubId);
+        return jpaHubRepository.findByHubIdAndDeletedAtIsNull(hubId);
     }
 
     @Override
     public boolean existsByHubName(String hubName) {
-        return jpaHubRepository.existsByHubName(hubName);
+        return jpaHubRepository.existsByHubNameAndDeletedAtIsNull(hubName);
     }
 
     @Override
     public List<Hub> findAll(Pageable pageable) {
-        return jpaHubRepository.findAll(pageable).getContent();
+        return jpaHubRepository.findAllByDeletedAtIsNull(pageable);
     }
 
 }

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
@@ -4,8 +4,10 @@ import com.tunaforce.hub.entity.Hub;
 import com.tunaforce.hub.repository.HubRepository;
 import com.tunaforce.hub.repository.jpa.JpaHubRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,6 +30,11 @@ public class HubRepositoryImpl implements HubRepository {
     @Override
     public boolean existsByHubName(String hubName) {
         return jpaHubRepository.existsByHubName(hubName);
+    }
+
+    @Override
+    public List<Hub> findAll(Pageable pageable) {
+        return jpaHubRepository.findAll(pageable).getContent();
     }
 
 }

--- a/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
@@ -1,10 +1,15 @@
 package com.tunaforce.hub.repository.jpa;
 
 import com.tunaforce.hub.entity.Hub;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
-    boolean existsByHubName(String hubName);
+    boolean existsByHubNameAndDeletedAtIsNull(String hubName);
+    Optional<Hub> findByHubIdAndDeletedAtIsNull(UUID hubId);
+    List<Hub> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/tunaforce/hub/service/HubService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubService.java
@@ -11,6 +11,9 @@ import com.tunaforce.hub.dto.response.HubUpdateResponseDto;
 import com.tunaforce.hub.entity.Hub;
 import com.tunaforce.hub.repository.HubRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -20,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -45,6 +49,7 @@ public class HubService {
     }
 
     @Transactional
+    @CacheEvict(value = "hub", allEntries = true)
     public HubUpdateResponseDto updateHub(UUID hubId, HubUpdateRequestDto requestDto) {
         Hub hub = readHub(hubId);   // 기존 허브 조회
 
@@ -70,6 +75,7 @@ public class HubService {
     }
 
     @Transactional
+    @CacheEvict(value = "hub", allEntries = true)
     public HubDeleteResponseDto deleteHub(UUID hubId) {
         Hub hub = readHub(hubId);   // 기존 허브 조회
 
@@ -80,7 +86,10 @@ public class HubService {
         return new HubDeleteResponseDto(true);
     }
 
+    @Cacheable(value = "hub", key = "#hubId")
     public HubGetResponseDto getHub(UUID hubId) {
+        log.info("캐시되지 않은 허브 조회: {}", hubId);
+
         Hub hub = readHub(hubId);   // 기존 허브 조회
 
         return new HubGetResponseDto(hub.getHubId(), hub.getHubName(), hub.getHubAddress(),


### PR DESCRIPTION
## 작업 내용
- 허브 조회 API 구현 (단건/목록)
- 단건 조회에 캐싱 적용

## 작업 상세 내용
- 허브 단건 조회 API
  - 응답 DTO (ID, 이름, 주소, 위도, 경도)
- 허브 목록 조회 API
  - page, size 쿼리 파라미터로 받아서 리스트 조회
- 삭제된 허브는 DB 조회 시 제외함
  - deletedAt 필드가 Null인 항목만 조회하도록 쿼리 메서드 수정
- Redis 캐싱 적용
  - 허브 단건 조회에만 적용
  - 조회 결과 캐싱 10분
  - 허브 수정, 삭제 시 캐시 내역 모두 삭제

## 기타 사항