### PR TITLE
[FEAT] 허브 생성 시 모든 경로 자동 생성 기능 추가

### DIFF
--- a/src/main/java/com/tunaforce/hub/common/config/NaverMapsConfig.java
+++ b/src/main/java/com/tunaforce/hub/common/config/NaverMapsConfig.java
@@ -16,7 +16,7 @@ public class NaverMapsConfig {
 
     // Geocoding API (주소 기반 위도, 경도 검색)
     @Bean
-    public WebClient naverGeocodingClient(WebClient.Builder webClientBuilder) {
+    public WebClient naverGeocodingClient() {
         return WebClient.builder()
                 .baseUrl("https://maps.apigw.ntruss.com/map-geocode/v2/geocode")
                 .defaultHeader("x-ncp-apigw-api-key-id", clientId)
@@ -26,7 +26,7 @@ public class NaverMapsConfig {
 
     // Directions5 API (최적 경로 검색)
     @Bean
-    public WebClient naverDirectionsClient(WebClient.Builder webClientBuilder) {
+    public WebClient naverDirectionsClient() {
         return WebClient.builder()
                 .baseUrl("https://maps.apigw.ntruss.com/map-direction/v1")
                 .defaultHeader("x-ncp-apigw-api-key-id", clientId)

--- a/src/main/java/com/tunaforce/hub/common/config/NaverMapsConfig.java
+++ b/src/main/java/com/tunaforce/hub/common/config/NaverMapsConfig.java
@@ -14,10 +14,21 @@ public class NaverMapsConfig {
     @Value("${naver.api.client-secret}")
     private String clientSecret;
 
+    // Geocoding API (주소 기반 위도, 경도 검색)
     @Bean
-    public WebClient naverMapsClient(WebClient.Builder webClientBuilder) {
+    public WebClient naverGeocodingClient(WebClient.Builder webClientBuilder) {
         return WebClient.builder()
                 .baseUrl("https://maps.apigw.ntruss.com/map-geocode/v2/geocode")
+                .defaultHeader("x-ncp-apigw-api-key-id", clientId)
+                .defaultHeader("x-ncp-apigw-api-key", clientSecret)
+                .build();
+    }
+
+    // Directions5 API (최적 경로 검색)
+    @Bean
+    public WebClient naverDirectionsClient(WebClient.Builder webClientBuilder) {
+        return WebClient.builder()
+                .baseUrl("https://maps.apigw.ntruss.com/map-direction/v1")
                 .defaultHeader("x-ncp-apigw-api-key-id", clientId)
                 .defaultHeader("x-ncp-apigw-api-key", clientSecret)
                 .build();

--- a/src/main/java/com/tunaforce/hub/common/exception/HubException.java
+++ b/src/main/java/com/tunaforce/hub/common/exception/HubException.java
@@ -15,6 +15,7 @@ public enum HubException {
     HUB_NO_CHANGE(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
 
     INVALID_PAGE_OR_SIZE(HttpStatus.BAD_REQUEST, "page는 0 이상의 정수, size는 1 이상의 정수여야 합니다."),
+    INVALID_HUB_ROUTE(HttpStatus.BAD_REQUEST, "유효한 경로를 찾을 수 없습니다."),
 
     // Auth
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/tunaforce/hub/controller/HubRouteController.java
+++ b/src/main/java/com/tunaforce/hub/controller/HubRouteController.java
@@ -1,0 +1,13 @@
+package com.tunaforce.hub.controller;
+
+import com.tunaforce.hub.service.HubRouteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/hub-routes")
+@RequiredArgsConstructor
+public class HubRouteController {
+    private final HubRouteService hubRouteService;
+}

--- a/src/main/java/com/tunaforce/hub/entity/HubRoute.java
+++ b/src/main/java/com/tunaforce/hub/entity/HubRoute.java
@@ -19,24 +19,24 @@ public class HubRoute extends Timestamped{
     private UUID hubRouteId;
 
     @Column(name = "origin_hub_id", nullable = false)
-    private UUID OriginHubId;
+    private UUID originHubId;
 
     @Column(name = "destination_hub_id", nullable = false)
-    private UUID DestinationHubId;
+    private UUID destinationHubId;
 
     @Column(name = "transit_time", nullable = false)
-    private Long transitTime;
+    private Long transitTime;       // Second
 
     @Column(name = "distance", nullable = false)
-    private Double distance;
+    private Double distance;        // Kilometer
 
     @Column(name = "comment")
     private String comment;
 
     @Builder
     public HubRoute(UUID originHubId, UUID destinationHubId, Long transitTime, Double distance) {
-        this.OriginHubId = originHubId;
-        this.DestinationHubId = destinationHubId;
+        this.originHubId = originHubId;
+        this.destinationHubId = destinationHubId;
         this.transitTime = transitTime;
         this.distance = distance;
     }

--- a/src/main/java/com/tunaforce/hub/entity/HubRoute.java
+++ b/src/main/java/com/tunaforce/hub/entity/HubRoute.java
@@ -1,0 +1,50 @@
+package com.tunaforce.hub.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "p_hub_route")
+public class HubRoute extends Timestamped{
+
+    @Id
+    @GeneratedValue
+    @Column(name = "hub_route_id", columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID hubRouteId;
+
+    @Column(name = "origin_hub_id", nullable = false)
+    private UUID OriginHubId;
+
+    @Column(name = "destination_hub_id", nullable = false)
+    private UUID DestinationHubId;
+
+    @Column(name = "transit_time", nullable = false)
+    private Long transitTime;
+
+    @Column(name = "distance", nullable = false)
+    private Double distance;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @Builder
+    public HubRoute(UUID originHubId, UUID destinationHubId, Long transitTime, Double distance) {
+        this.OriginHubId = originHubId;
+        this.DestinationHubId = destinationHubId;
+        this.transitTime = transitTime;
+        this.distance = distance;
+    }
+
+    public void update(Long transitTime, Double distance, String comment) {
+        this.transitTime = transitTime;
+        this.distance = distance;
+        this.comment = comment;
+    }
+
+}

--- a/src/main/java/com/tunaforce/hub/repository/HubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/HubRepository.java
@@ -12,4 +12,5 @@ public interface HubRepository{
     Optional<Hub> findById(UUID hubId);
     boolean existsByHubName(String hubName);
     List<Hub> findAll(Pageable pageable);
+    List<Hub> findAllByHubIdNot(UUID hubId);
 }

--- a/src/main/java/com/tunaforce/hub/repository/HubRouteRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/HubRouteRepository.java
@@ -1,0 +1,11 @@
+package com.tunaforce.hub.repository;
+
+import com.tunaforce.hub.entity.HubRoute;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HubRouteRepository {
+    HubRoute save(HubRoute hubRoute);
+    Optional<HubRoute> findByHubId(UUID originHubId,  UUID destinationHubId);
+}

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
@@ -37,4 +37,10 @@ public class HubRepositoryImpl implements HubRepository {
         return jpaHubRepository.findAllByDeletedAtIsNull(pageable);
     }
 
+    @Override
+    public List<Hub> findAllByHubIdNot(UUID hubId) {
+        return jpaHubRepository.findAllByHubIdNot(hubId);
+    }
+
+
 }

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRouteRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRouteRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.tunaforce.hub.repository.impl;
+
+import com.tunaforce.hub.entity.HubRoute;
+import com.tunaforce.hub.repository.HubRouteRepository;
+import com.tunaforce.hub.repository.jpa.JpaHubRouteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRouteRepositoryImpl implements HubRouteRepository {
+    private final JpaHubRouteRepository jpaHubRouteRepository;
+
+
+    @Override
+    public HubRoute save(HubRoute hubRoute) {
+        return jpaHubRouteRepository.save(hubRoute);
+    }
+
+    @Override
+    public Optional<HubRoute> findByHubId(UUID originHubId, UUID destinationHubId) {
+        return jpaHubRouteRepository.findByOriginHubIdAndDestinationHubIdAndDeletedAtIsNull(originHubId, destinationHubId);
+    }
+
+}

--- a/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
@@ -12,4 +12,5 @@ public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
     boolean existsByHubNameAndDeletedAtIsNull(String hubName);
     Optional<Hub> findByHubIdAndDeletedAtIsNull(UUID hubId);
     List<Hub> findAllByDeletedAtIsNull(Pageable pageable);
+    List<Hub> findAllByHubIdNot(UUID hubId);
 }

--- a/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRouteRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRouteRepository.java
@@ -1,0 +1,12 @@
+package com.tunaforce.hub.repository.jpa;
+
+import com.tunaforce.hub.entity.HubRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID> {
+    Optional<HubRoute> findByOriginHubIdAndDestinationHubIdAndDeletedAtIsNull(UUID originHubId, UUID destinationHubId);
+}
+

--- a/src/main/java/com/tunaforce/hub/service/HubRouteService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubRouteService.java
@@ -50,6 +50,6 @@ public class HubRouteService {
                 .distance(distance)
                 .build();
 
-        HubRoute savedHubRoute = hubRouteRepository.save(hubRoute);
+        hubRouteRepository.save(hubRoute);
     }
 }

--- a/src/main/java/com/tunaforce/hub/service/HubRouteService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubRouteService.java
@@ -1,0 +1,55 @@
+package com.tunaforce.hub.service;
+
+import com.tunaforce.hub.entity.Hub;
+import com.tunaforce.hub.entity.HubRoute;
+import com.tunaforce.hub.repository.HubRepository;
+import com.tunaforce.hub.repository.HubRouteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubRouteService {
+    private final HubRouteRepository hubRouteRepository;
+    private final HubRepository hubRepository;
+    private final NaverMapsService naverMapsService;
+
+    @Transactional
+    public void createHubRoutesAutomatically(Hub newHub){
+        // newHub를 제외한 기존 허브 모두 조회
+        List<Hub> hubList = hubRepository.findAllByHubIdNot(newHub.getHubId());
+
+        // newHub를 출발지로 설정, 모든 허브와 연결
+        for(Hub goalHub : hubList){
+            createHubRoute(newHub, goalHub);
+        }
+
+        // newHub를 도착지로 설정, 모든 허브와 연결
+        for(Hub startHub : hubList){
+            createHubRoute(startHub, newHub);
+        }
+    }
+
+    private void createHubRoute(Hub startHub, Hub goalHub){
+        // Naver Maps API 호출하여 이동 거리와 시간 검색
+        Map<String, Number> directions = naverMapsService.getDirections(startHub, goalHub);
+        Double distance = directions.get("distance").doubleValue();
+        Long transitTime = directions.get("transitTime").longValue();
+
+        HubRoute hubRoute = HubRoute.builder()
+                .originHubId(startHub.getHubId())
+                .destinationHubId(goalHub.getHubId())
+                .transitTime(transitTime)
+                .distance(distance)
+                .build();
+
+        HubRoute savedHubRoute = hubRouteRepository.save(hubRoute);
+    }
+}

--- a/src/main/java/com/tunaforce/hub/service/NaverMapsService.java
+++ b/src/main/java/com/tunaforce/hub/service/NaverMapsService.java
@@ -3,38 +3,35 @@ package com.tunaforce.hub.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.tunaforce.hub.common.exception.ApplicationException;
 import com.tunaforce.hub.common.exception.HubException;
+import com.tunaforce.hub.entity.Hub;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NaverMapsService {
-    private final WebClient webClient;
-
-    /*주소를 매개변수로 받아서 위도를 반환하는 메서드*/
-    public Double getLatitude(String address) {
-        Map<String, Double> coordinates = getCoordinates(address);
-        return coordinates.get("latitude");
-    }
-
-    /*주소를 매개변수로 받아서 경도를 반환하는 메서드*/
-    public Double getLongitude(String address) {
-        Map<String, Double> coordinates = getCoordinates(address);
-        return coordinates.get("longitude");
-    }
+    private final WebClient naverGeocodingClient;   // Geocoding API
+    private final WebClient naverDirectionsClient;  // Directions5 API
 
     /* Naver Maps API로부터 위도, 경도 받아오는 메서드*/
-    private Map<String, Double> getCoordinates(String address) {
-        JsonNode response = webClient.get()
+    public Map<String, Double> getCoordinates(String address) {
+        log.info("주소로 좌표 검색 시작: {}", address);
+
+        JsonNode response = naverGeocodingClient.get()
                 .uri(uriBuilder -> uriBuilder.queryParam("query", address).build())
                 .retrieve()
                 .bodyToMono(JsonNode.class)
                 .block();
 
+        log.info("Geocoding API 응답: {}", response);
+
         if (response == null || response.get("addresses").isEmpty()) {
+            log.error("유효하지 않은 주소: {}", address);
             throw new ApplicationException(HubException.INVALID_HUB_ADDRESS);
         }
 
@@ -42,6 +39,118 @@ public class NaverMapsService {
         double longitude = addresses.get("x").asDouble();
         double latitude = addresses.get("y").asDouble();
 
+        log.info("좌표 변환 결과 - 위도: {}, 경도: {}", latitude, longitude);
         return Map.of("latitude", latitude, "longitude", longitude);
+    }
+
+    /* Naver Maps API로부터 최적 경로 정보를 받아오는 메서드*/
+    public Map<String, Number> getDirections(Hub startHub, Hub goalHub) {
+        // 좌표값 유효성 검증 추가
+        if (startHub.getHubLatitude() == null || startHub.getHubLongitude() == null ||
+                goalHub.getHubLatitude() == null || goalHub.getHubLongitude() == null) {
+            log.error("허브 좌표 정보가 누락됨 - 출발지: lat={}, lng={}, 도착지: lat={}, lng={}",
+                    startHub.getHubLatitude(), startHub.getHubLongitude(),
+                    goalHub.getHubLatitude(), goalHub.getHubLongitude());
+            throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+        }
+
+        String start = startHub.getHubLongitude() + "," + startHub.getHubLatitude();
+        String goal = goalHub.getHubLongitude() + "," + goalHub.getHubLatitude();
+
+        log.info("경로 검색 시작 - 출발지: {} ({}), 도착지: {} ({})",
+                startHub.getHubName(), start, goalHub.getHubName(), goal);
+
+        try {
+            JsonNode response = naverDirectionsClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/driving")
+                            .queryParam("start", start)
+                            .queryParam("goal", goal)
+                            .queryParam("option", "trafast")
+                            .queryParam("cartype", 2)
+                            .build())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            log.info("Directions API 전체 응답: {}", response);
+
+            // 응답 구조 상세 로깅
+            if (response == null) {
+                log.error("Directions API 응답이 null");
+                throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+            }
+
+            // 오류 코드 확인
+            if (response.has("code") && response.get("code").asInt() != 0) {
+                log.error("Directions API 오류 코드: {}, 메시지: {}",
+                        response.get("code").asInt(),
+                        response.has("message") ? response.get("message").asText() : "알 수 없는 오류");
+                throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+            }
+
+            JsonNode routeNode = response.get("route");
+            if (routeNode == null) {
+                log.error("route 노드가 존재하지 않음");
+                throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+            }
+
+            log.info("route 노드 내용: {}", routeNode);
+
+            // traoptimal이 아닌 다른 경로 옵션도 확인
+            String[] routeOptions = {"traoptimal", "trafast", "tracomfort"};
+            JsonNode selectedRoute = null;
+            String selectedOption = null;
+
+            for (String option : routeOptions) {
+                if (routeNode.has(option) && routeNode.get(option).isArray() && routeNode.get(option).size() > 0) {
+                    selectedRoute = routeNode.get(option);
+                    selectedOption = option;
+                    log.info("경로 옵션 '{}' 사용 가능", option);
+                    break;
+                }
+            }
+
+            if (selectedRoute == null) {
+                log.error("사용 가능한 경로 옵션이 없음. route 노드: {}", routeNode);
+                throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+            }
+
+            JsonNode firstRoute = selectedRoute.get(0);
+            log.info("선택된 경로 ({}) 첫 번째 항목: {}", selectedOption, firstRoute);
+
+            JsonNode summary = firstRoute.get("summary");
+            if (summary == null) {
+                log.error("summary 노드가 존재하지 않음. firstRoute: {}", firstRoute);
+                throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+            }
+
+            log.info("summary 노드 내용: {}", summary);
+
+            if (!summary.has("distance") || !summary.has("duration")) {
+                log.error("distance 또는 duration 필드가 없음. summary: {}", summary);
+                throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+            }
+
+            double distance = summary.get("distance").asDouble();
+            int transitTime = summary.get("duration").asInt();
+
+            log.info("경로 정보 - 거리: {}m, 소요시간: {}ms", distance, transitTime);
+
+            // 단위 변환 (미터 -> 킬로미터, 밀리초 -> 초)
+            double distanceInKm = distance / 1000.0;
+            long transitTimeInSeconds = transitTime / 1000L;
+
+            log.info("변환된 경로 정보 - 거리: {}km, 소요시간: {}초", distanceInKm, transitTimeInSeconds);
+
+            return Map.of(
+                    "distance", distanceInKm,
+                    "transitTime", transitTimeInSeconds
+            );
+
+        } catch (Exception e) {
+            log.error("Directions API 호출 중 오류 발생: {}", e.getMessage(), e);
+            throw new ApplicationException(HubException.INVALID_HUB_ROUTE);
+        }
     }
 }

--- a/src/main/java/com/tunaforce/hub/service/NaverMapsService.java
+++ b/src/main/java/com/tunaforce/hub/service/NaverMapsService.java
@@ -103,7 +103,7 @@ public class NaverMapsService {
             String selectedOption = null;
 
             for (String option : routeOptions) {
-                if (routeNode.has(option) && routeNode.get(option).isArray() && routeNode.get(option).size() > 0) {
+                if (routeNode.has(option) && routeNode.get(option).isArray() && !routeNode.get(option).isEmpty()) {
                     selectedRoute = routeNode.get(option);
                     selectedOption = option;
                     log.info("경로 옵션 '{}' 사용 가능", option);


### PR DESCRIPTION
## 작업 내용
- HubRoute 엔티티 생성
- 허브 생성 시 모든 경로 자동 생성 기능 추가

## 작업 상세 내용
- HubRoute 엔티티 생성
  - 식별자 UUID
  - 출발 허브 ID, 도착 허브 ID, 소요 시간, 이동 거리, 비고
- HubService의 허브 생성 메서드 수정
  -  허브 저장 후 새 허브와 기존 허브 간 경로를 자동 생성하는 메서드 호출
- HubRouteService 추가
  - 새 허브와 기존 허브 간 경로를 자동 생성하는 메서드 구현
  - 출발지와 목적지를 파라미터로 받아서 경로를 생성하는 로직은 private method로 분리
  - 허브 간 경로 생성 모델은 P2P 적용 (양방향)
- NaverMapsConfig
  - 기존 Geocoding API 연동을 위한 WebClient 유지 (위도, 경도 검색)
  - Directions5 API 연동을 위한 WebClient 추가
- NaverMapsService
  - getCoordinates(String address) 메서드가 불필요하게 중복 호출되는 문제 수정
  - getDirections(Hub startHub, Hub goalHub) 메서드 추가 (경로 검색)

## 기타 사항