### PR TITLE
[FEAT] 허브 간 이동 경로 관리 기능 추가

### DIFF
--- a/src/main/java/com/tunaforce/hub/common/exception/HubException.java
+++ b/src/main/java/com/tunaforce/hub/common/exception/HubException.java
@@ -13,9 +13,11 @@ public enum HubException {
     HUB_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 동일한 허브명이 존재합니다."),
     INVALID_HUB_ADDRESS(HttpStatus.BAD_REQUEST, "유효하지 않은 주소입니다."),
     HUB_NO_CHANGE(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
-
     INVALID_PAGE_OR_SIZE(HttpStatus.BAD_REQUEST, "page는 0 이상의 정수, size는 1 이상의 정수여야 합니다."),
+
+    // HubRoute
     INVALID_HUB_ROUTE(HttpStatus.BAD_REQUEST, "유효한 경로를 찾을 수 없습니다."),
+    HUB_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "허브 간 이동 경로를 찾을 수 없습니다."),
 
     // Auth
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/tunaforce/hub/common/exception/HubException.java
+++ b/src/main/java/com/tunaforce/hub/common/exception/HubException.java
@@ -13,7 +13,7 @@ public enum HubException {
     HUB_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 동일한 허브명이 존재합니다."),
     INVALID_HUB_ADDRESS(HttpStatus.BAD_REQUEST, "유효하지 않은 주소입니다."),
     HUB_NO_CHANGE(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
-    INVALID_PAGE_OR_SIZE(HttpStatus.BAD_REQUEST, "page는 0 이상의 정수, size는 1 이상의 정수여야 합니다."),
+    INVALID_PAGE_OR_SIZE(HttpStatus.BAD_REQUEST, "page, size는 0 이상의 정수여야 합니다."),
 
     // HubRoute
     INVALID_HUB_ROUTE(HttpStatus.BAD_REQUEST, "유효한 경로를 찾을 수 없습니다."),

--- a/src/main/java/com/tunaforce/hub/controller/HubRouteController.java
+++ b/src/main/java/com/tunaforce/hub/controller/HubRouteController.java
@@ -1,13 +1,26 @@
 package com.tunaforce.hub.controller;
 
+import com.tunaforce.hub.dto.response.HubRouteGetResponseDto;
 import com.tunaforce.hub.service.HubRouteService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/hub-routes")
 @RequiredArgsConstructor
 public class HubRouteController {
     private final HubRouteService hubRouteService;
+
+    @GetMapping
+    public ResponseEntity<HubRouteGetResponseDto> getHubRoute(@RequestParam UUID from,
+                                                              @RequestParam UUID to){
+        return new ResponseEntity<>(hubRouteService.getHubRoute(from, to), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/tunaforce/hub/controller/HubRouteController.java
+++ b/src/main/java/com/tunaforce/hub/controller/HubRouteController.java
@@ -1,14 +1,13 @@
 package com.tunaforce.hub.controller;
 
+import com.tunaforce.hub.dto.request.HubRouteUpdateRequestDto;
 import com.tunaforce.hub.dto.response.HubRouteGetResponseDto;
 import com.tunaforce.hub.service.HubRouteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -22,5 +21,11 @@ public class HubRouteController {
     public ResponseEntity<HubRouteGetResponseDto> getHubRoute(@RequestParam UUID from,
                                                               @RequestParam UUID to){
         return new ResponseEntity<>(hubRouteService.getHubRoute(from, to), HttpStatus.OK);
+    }
+
+    @PutMapping("/{hubRouteId}")
+    public ResponseEntity<HubRouteGetResponseDto> updateOneHubRoute(@PathVariable UUID hubRouteId,
+                                                                    @Validated @RequestBody HubRouteUpdateRequestDto requestDto){
+        return new ResponseEntity<>(hubRouteService.updateOneHubRoute(hubRouteId, requestDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/tunaforce/hub/dto/request/HubRouteUpdateRequestDto.java
+++ b/src/main/java/com/tunaforce/hub/dto/request/HubRouteUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package com.tunaforce.hub.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record HubRouteUpdateRequestDto(
+        @NotNull(message = "경로 업데이트 사유를 작성해주세요.") String comment
+) {
+}

--- a/src/main/java/com/tunaforce/hub/dto/response/HubRouteGetResponseDto.java
+++ b/src/main/java/com/tunaforce/hub/dto/response/HubRouteGetResponseDto.java
@@ -1,0 +1,10 @@
+package com.tunaforce.hub.dto.response;
+
+import java.util.UUID;
+
+public record HubRouteGetResponseDto(UUID HubRouteId,
+                                     String originHubName,
+                                     String destinationHubName,
+                                     Long transitTime,
+                                     Double distance) {
+}

--- a/src/main/java/com/tunaforce/hub/repository/HubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/HubRepository.java
@@ -2,6 +2,7 @@ package com.tunaforce.hub.repository;
 
 import com.tunaforce.hub.entity.Hub;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +14,5 @@ public interface HubRepository{
     boolean existsByHubName(String hubName);
     List<Hub> findAll(Pageable pageable);
     List<Hub> findAllByHubIdNot(UUID hubId);
+    List<Hub> findAll(Sort sort);
 }

--- a/src/main/java/com/tunaforce/hub/repository/HubRouteRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/HubRouteRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 public interface HubRouteRepository {
     HubRoute save(HubRoute hubRoute);
     Optional<HubRoute> findByHubId(UUID originHubId,  UUID destinationHubId);
+    Optional<HubRoute> findByHubRouteId(UUID hubRouteId);
 }

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
@@ -39,7 +39,7 @@ public class HubRepositoryImpl implements HubRepository {
 
     @Override
     public List<Hub> findAllByHubIdNot(UUID hubId) {
-        return jpaHubRepository.findAllByHubIdNot(hubId);
+        return jpaHubRepository.findAllByHubIdNotAndDeletedAtIsNull(hubId);
     }
 
 

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.tunaforce.hub.repository.HubRepository;
 import com.tunaforce.hub.repository.jpa.JpaHubRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -40,6 +41,11 @@ public class HubRepositoryImpl implements HubRepository {
     @Override
     public List<Hub> findAllByHubIdNot(UUID hubId) {
         return jpaHubRepository.findAllByHubIdNotAndDeletedAtIsNull(hubId);
+    }
+
+    @Override
+    public List<Hub> findAll(Sort sort) {
+        return jpaHubRepository.findAllByDeletedAtIsNull(sort);
     }
 
 

--- a/src/main/java/com/tunaforce/hub/repository/impl/HubRouteRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/hub/repository/impl/HubRouteRepositoryImpl.java
@@ -25,4 +25,9 @@ public class HubRouteRepositoryImpl implements HubRouteRepository {
         return jpaHubRouteRepository.findByOriginHubIdAndDestinationHubIdAndDeletedAtIsNull(originHubId, destinationHubId);
     }
 
+    @Override
+    public Optional<HubRoute> findByHubRouteId(UUID hubRouteId) {
+        return jpaHubRouteRepository.findByHubRouteIdAndDeletedAtIsNull(hubRouteId);
+    }
+
 }

--- a/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
@@ -12,5 +12,5 @@ public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
     boolean existsByHubNameAndDeletedAtIsNull(String hubName);
     Optional<Hub> findByHubIdAndDeletedAtIsNull(UUID hubId);
     List<Hub> findAllByDeletedAtIsNull(Pageable pageable);
-    List<Hub> findAllByHubIdNot(UUID hubId);
+    List<Hub> findAllByHubIdNotAndDeletedAtIsNull(UUID hubId);
 }

--- a/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRepository.java
@@ -2,6 +2,7 @@ package com.tunaforce.hub.repository.jpa;
 
 import com.tunaforce.hub.entity.Hub;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,5 +13,6 @@ public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
     boolean existsByHubNameAndDeletedAtIsNull(String hubName);
     Optional<Hub> findByHubIdAndDeletedAtIsNull(UUID hubId);
     List<Hub> findAllByDeletedAtIsNull(Pageable pageable);
+    List<Hub> findAllByDeletedAtIsNull(Sort sort);
     List<Hub> findAllByHubIdNotAndDeletedAtIsNull(UUID hubId);
 }

--- a/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRouteRepository.java
+++ b/src/main/java/com/tunaforce/hub/repository/jpa/JpaHubRouteRepository.java
@@ -8,5 +8,6 @@ import java.util.UUID;
 
 public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID> {
     Optional<HubRoute> findByOriginHubIdAndDestinationHubIdAndDeletedAtIsNull(UUID originHubId, UUID destinationHubId);
+    Optional<HubRoute> findByHubRouteIdAndDeletedAtIsNull(UUID hubRouteId);
 }
 

--- a/src/main/java/com/tunaforce/hub/service/HubRouteService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubRouteService.java
@@ -10,6 +10,8 @@ import com.tunaforce.hub.repository.HubRepository;
 import com.tunaforce.hub.repository.HubRouteRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,8 +28,10 @@ public class HubRouteService {
     private final HubRepository hubRepository;
     private final NaverMapsService naverMapsService;
 
+    @Cacheable(value = "hubRoute", key = "#from + '-' + #to")
     @Transactional
     public HubRouteGetResponseDto getHubRoute(UUID from, UUID to) {
+        log.info(" 캐시되지 않은 허브 경로 조회!!!");
         HubRoute hubRoute = hubRouteRepository.findByHubId(from, to)
                 .orElseThrow(()-> new ApplicationException(HubException.HUB_ROUTE_NOT_FOUND));
 
@@ -41,6 +45,7 @@ public class HubRouteService {
     }
 
     @Transactional
+    @CacheEvict(value = "hubRoute", allEntries = true)
     public HubRouteGetResponseDto updateOneHubRoute(UUID hubRouteId, HubRouteUpdateRequestDto requestDto) {
         HubRoute hubRoute = hubRouteRepository.findByHubRouteId(hubRouteId)
                 .orElseThrow(()-> new ApplicationException(HubException.HUB_ROUTE_NOT_FOUND));
@@ -78,6 +83,7 @@ public class HubRouteService {
     }
 
     @Transactional
+    @CacheEvict(value = "hubRoute", allEntries = true)
     public void updateHubRoutesAutomatically(Hub newHub){
         // newHub를 제외한 기존 허브 모두 조회
         List<Hub> hubList = hubRepository.findAllByHubIdNot(newHub.getHubId());
@@ -94,6 +100,7 @@ public class HubRouteService {
     }
 
     @Transactional
+    @CacheEvict(value = "hubRoute", allEntries = true)
     public void deleteHubRoutesAutomatically(Hub newHub){
         // newHub를 제외한 기존 허브 모두 조회
         List<Hub> hubList = hubRepository.findAllByHubIdNot(newHub.getHubId());

--- a/src/main/java/com/tunaforce/hub/service/HubRouteService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubRouteService.java
@@ -1,5 +1,7 @@
 package com.tunaforce.hub.service;
 
+import com.tunaforce.hub.common.exception.ApplicationException;
+import com.tunaforce.hub.common.exception.HubException;
 import com.tunaforce.hub.entity.Hub;
 import com.tunaforce.hub.entity.HubRoute;
 import com.tunaforce.hub.repository.HubRepository;
@@ -37,6 +39,23 @@ public class HubRouteService {
         }
     }
 
+    @Transactional
+    public void updateHubRoutesAutomatically(Hub newHub){
+        // newHub를 제외한 기존 허브 모두 조회
+        List<Hub> hubList = hubRepository.findAllByHubIdNot(newHub.getHubId());
+
+        // newHub를 출발지로 설정, 모든 허브와의 경로 업데이트
+        for(Hub goalHub : hubList){
+            updateHubRoute(newHub, goalHub);
+        }
+
+        // newHub를 도착지로 설정, 모든 허브와의 경로 업데이트
+        for(Hub startHub : hubList){
+            updateHubRoute(startHub, newHub);
+        }
+    }
+
+    /*출발허브, 도착허브 인스턴스를 매개변수로 받아서 허브 경로 생성 */
     private void createHubRoute(Hub startHub, Hub goalHub){
         // Naver Maps API 호출하여 이동 거리와 시간 검색
         Map<String, Number> directions = naverMapsService.getDirections(startHub, goalHub);
@@ -51,5 +70,19 @@ public class HubRouteService {
                 .build();
 
         hubRouteRepository.save(hubRoute);
+    }
+
+    /*출발허브, 도착허브 인스턴스를 매개변수로 받아서 허브 경로 업데이트 */
+    private void updateHubRoute(Hub startHub, Hub goalHub){
+        // Naver Maps API 호출하여 이동 거리와 시간 검색
+        Map<String, Number> directions = naverMapsService.getDirections(startHub, goalHub);
+        Double distance = directions.get("distance").doubleValue();
+        Long transitTime = directions.get("transitTime").longValue();
+
+        HubRoute hubRoute = hubRouteRepository.findByHubId(startHub.getHubId(), goalHub.getHubId())
+                .orElseThrow(()-> new ApplicationException(HubException.HUB_ROUTE_NOT_FOUND));
+
+        //허브 경로 업데이트
+        hubRoute.update(transitTime, distance, "허브 정보 변경");
     }
 }

--- a/src/main/java/com/tunaforce/hub/service/HubRouteService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubRouteService.java
@@ -2,6 +2,7 @@ package com.tunaforce.hub.service;
 
 import com.tunaforce.hub.common.exception.ApplicationException;
 import com.tunaforce.hub.common.exception.HubException;
+import com.tunaforce.hub.dto.response.HubRouteGetResponseDto;
 import com.tunaforce.hub.entity.Hub;
 import com.tunaforce.hub.entity.HubRoute;
 import com.tunaforce.hub.repository.HubRepository;
@@ -23,6 +24,20 @@ public class HubRouteService {
     private final HubRouteRepository hubRouteRepository;
     private final HubRepository hubRepository;
     private final NaverMapsService naverMapsService;
+
+    @Transactional
+    public HubRouteGetResponseDto getHubRoute(UUID from, UUID to) {
+        HubRoute hubRoute = hubRouteRepository.findByHubId(from, to)
+                .orElseThrow(()-> new ApplicationException(HubException.HUB_ROUTE_NOT_FOUND));
+
+        String originHubName = hubRepository.findById(hubRoute.getOriginHubId())
+                .orElseThrow(()-> new ApplicationException(HubException.HUB_NOT_FOUND)).getHubName();
+        String destinationHubName = hubRepository.findById(hubRoute.getDestinationHubId())
+                .orElseThrow(()-> new ApplicationException(HubException.HUB_NOT_FOUND)).getHubName();
+
+        return new HubRouteGetResponseDto(hubRoute.getHubRouteId(),
+                originHubName, destinationHubName, hubRoute.getTransitTime(), hubRoute.getDistance());
+    }
 
     @Transactional
     public void createHubRoutesAutomatically(Hub newHub){

--- a/src/main/java/com/tunaforce/hub/service/HubService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubService.java
@@ -119,13 +119,17 @@ public class HubService {
     }
 
     public List<HubGetResponseDto> getHubList(int page, int size) {
-        if(page < 0 || size <= 0) {
+        if(page < 0 || size < 0) {
             throw new ApplicationException(HubException.INVALID_PAGE_OR_SIZE);
         }
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").ascending());
-        List<Hub> hubs = hubRepository.findAll(pageable);
-
+        List<Hub> hubs;
+        if(size == 0){
+            hubs = hubRepository.findAll(Sort.by("createdAt").ascending());
+        } else{
+            Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").ascending());
+            hubs = hubRepository.findAll(pageable);
+        }
         return hubs.stream()
                 .map(hub -> new HubGetResponseDto(
                         hub.getHubId(),

--- a/src/main/java/com/tunaforce/hub/service/HubService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubService.java
@@ -85,8 +85,8 @@ public class HubService {
                 longitude,
                 requestDto.comment());
 
-        // 허브 경로 서비스 호출, 허브 간 이동 경로 자동 생성
-        hubRouteService.createHubRoutesAutomatically(hub);
+        // 허브 경로 서비스 호출, 허브 간 이동 경로 자동 업데이트
+        hubRouteService.updateHubRoutesAutomatically(hub);
 
         return new HubUpdateResponseDto(hub.getHubId());
 

--- a/src/main/java/com/tunaforce/hub/service/HubService.java
+++ b/src/main/java/com/tunaforce/hub/service/HubService.java
@@ -101,6 +101,10 @@ public class HubService {
         /*임시로 랜덤 UUID 넣어줌, 추후 수정 필요*/
         UUID userId = UUID.randomUUID();
         hub.delete(userId);
+
+        // 허브 경로 서비스 호출, 허브 간 이동 경로 자동 삭제
+        hubRouteService.deleteHubRoutesAutomatically(hub);
+
         return new HubDeleteResponseDto(true);
     }
 


### PR DESCRIPTION
## 작업 내용
- 허브 경로 자동 관리 기능 보완
- 허브 간 이동 경로 단건 조회 API 구현
- 허브 간 이동 경로 단건 수정 API 구현

## 작업 상세 내용
- 허브 경로 자동 관리 기능 보완
  - 허브 수정 API 호출 시, 관련된 기존 경로 자동 업데이트
  - 허브 삭제 API 호출 시, 관련된 기존 경로 자동 삭제 (소프트삭제)
- 허브 간 이동 경로 단건 조회 API
  - /hub-routes?from={출발허브ID}&to={도착허브ID}
  - Redis 캐싱 적용 (조회 결과 10분 캐싱, 수정 및 삭제 시 캐시 초기화)
- 허브 간 이동 경로 단건 수정 API
  - @PathVariable hubRouteId
  - 경로 ID로 하나의 경로 수정, 네이버 지도 API 호출로 자동 업데이트
  - 도로 공사 등 경로에 문제 시 변경하는 용도

## 기타 사항
- 허브 목록 조회 API 수정
  - size = 0 으로 조회 시 전체 목록이 조회되도록 했습니다! (성운님 요청)